### PR TITLE
Add an rfcs directory and template in the Go buildpack

### DIFF
--- a/rfcs/0000-template.md
+++ b/rfcs/0000-template.md
@@ -1,0 +1,23 @@
+# {{TITLE: a human-readable title for this RFC!}}
+
+## Proposal
+
+{{What changes are you purposing to the overall language family?}}
+
+## Motivation
+
+{{Why are we doing this? What pain points does this resolve? What use cases does it support? What is the expected outcome? Use real, concrete examples to make your case!}}
+
+## Implementation (Optional)
+
+{{Give a high-level overview of implementation requirements and concerns. Be specific about areas of code that need to change, and what their potential effects are. Discuss which repositories and sub-components will be affected, and what its overall code effect might be.}}
+
+## Source Material (Optional)
+
+{{Any source material used in the creation of the RFC should be put here.}}
+
+## Unresolved Questions and Bikeshedding (Optional)
+
+{{Write about any arbitrary decisions that need to be made (syntax, colors, formatting, minor UX decisions), and any questions for the proposal that have not been answered.}}
+
+{{REMOVE THIS SECTION BEFORE RATIFICATION!}}


### PR DESCRIPTION
Adds an rfcs directory and template in the Go buildpack for high-level language specific changes to be purposed.

[Readable template](https://github.com/paketo-buildpacks/go/blob/add-rfcs/rfcs/0000-template.md)