### PR TITLE
Removes ContainerLogs from integration suite

### DIFF
--- a/integration/build_test.go
+++ b/integration/build_test.go
@@ -60,7 +60,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			container, err = docker.Container.Run.Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(container).Should(BeAvailable(), ContainerLogs(container.ID))
+			Eventually(container).Should(BeAvailable())
 
 			response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort()))
 			Expect(err).NotTo(HaveOccurred())

--- a/integration/dep_test.go
+++ b/integration/dep_test.go
@@ -60,7 +60,7 @@ func testDep(t *testing.T, context spec.G, it spec.S) {
 			container, err = docker.Container.Run.Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(container).Should(BeAvailable(), ContainerLogs(container.ID))
+			Eventually(container).Should(BeAvailable())
 
 			response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort()))
 			Expect(err).NotTo(HaveOccurred())

--- a/integration/go_mod_test.go
+++ b/integration/go_mod_test.go
@@ -60,7 +60,7 @@ func testGoMod(t *testing.T, context spec.G, it spec.S) {
 			container, err = docker.Container.Run.Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(container).Should(BeAvailable(), ContainerLogs(container.ID))
+			Eventually(container).Should(BeAvailable())
 
 			response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort()))
 			Expect(err).NotTo(HaveOccurred())

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/paketo-buildpacks/occam"
 	"github.com/paketo-buildpacks/packit/pexec"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
@@ -38,13 +37,4 @@ func TestIntegration(t *testing.T) {
 	suite("Dep", testDep)
 	suite("GoMod", testGoMod)
 	suite.Run(t)
-}
-
-func ContainerLogs(id string) func() string {
-	docker := occam.NewDocker()
-
-	return func() string {
-		logs, _ := docker.Container.Logs.Execute(id)
-		return logs.String()
-	}
 }


### PR DESCRIPTION
The `BeAvailable` method will already fetch logs if the assertion fails