### PR TITLE
Add optional procfile to all order groups

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -22,6 +22,11 @@ api = "0.2"
     id = "paketo-buildpacks/go-build"
     version = "0.1.2"
 
+  [[order.group]]
+    id = "paketo-buildpacks/procfile"
+    optional = true
+    version = "3.0.0"
+
 [[order]]
 
   [[order.group]]
@@ -40,6 +45,11 @@ api = "0.2"
     id = "paketo-buildpacks/go-build"
     version = "0.1.2"
 
+  [[order.group]]
+    id = "paketo-buildpacks/procfile"
+    optional = true
+    version = "3.0.0"
+
 [[order]]
 
   [[order.group]]
@@ -49,3 +59,8 @@ api = "0.2"
   [[order.group]]
     id = "paketo-buildpacks/go-build"
     version = "0.1.2"
+
+  [[order.group]]
+    id = "paketo-buildpacks/procfile"
+    optional = true
+    version = "3.0.0"

--- a/integration/dep_test.go
+++ b/integration/dep_test.go
@@ -89,5 +89,47 @@ func testDep(t *testing.T, context spec.G, it spec.S) {
 
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Go Mod Vendor Buildpack")))
 		})
+
+		context("when there is a Procfile", func() {
+			it.Before(func() {
+				Expect(ioutil.WriteFile(filepath.Join(source, "Procfile"), []byte("web: /layers/paketo-buildpacks_go-build/targets/bin/workspace --some-arg"), 0644)).To(Succeed())
+			})
+
+			it("uses Procfile to set start command", func() {
+				var err error
+				var logs fmt.Stringer
+				image, logs, err = pack.WithNoColor().Build.
+					WithBuildpacks(goBuildpack).
+					WithPullPolicy("never").
+					Execute(name, source)
+				Expect(err).NotTo(HaveOccurred(), logs.String())
+
+				container, err = docker.Container.Run.
+					WithEnv(map[string]string{"PORT": "8080"}).
+					WithPublish("8080").
+					WithPublishAll().
+					Execute(image.ID)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(container).Should(BeAvailable())
+
+				response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
+				Expect(err).NotTo(HaveOccurred())
+				defer response.Body.Close()
+
+				Expect(response.StatusCode).To(Equal(http.StatusOK))
+
+				content, err := ioutil.ReadAll(response.Body)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(content)).To(ContainSubstring("Hello, World!"))
+
+				Expect(logs).To(ContainLines(ContainSubstring("Go Distribution Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Dep Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Dep Ensure Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Go Build Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Procfile Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("web: /layers/paketo-buildpacks_go-build/targets/bin/workspace --some-arg")))
+			})
+		})
 	})
 }

--- a/integration/go_mod_test.go
+++ b/integration/go_mod_test.go
@@ -88,5 +88,46 @@ func testGoMod(t *testing.T, context spec.G, it spec.S) {
 
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Dep Buildpack")))
 		})
+
+		context("when there is a Procfile", func() {
+			it.Before(func() {
+				Expect(ioutil.WriteFile(filepath.Join(source, "Procfile"), []byte("web: /layers/paketo-buildpacks_go-build/targets/bin/go-online --some-arg"), 0644)).To(Succeed())
+			})
+
+			it("uses Procfile to set start command", func() {
+				var err error
+				var logs fmt.Stringer
+				image, logs, err = pack.WithNoColor().Build.
+					WithBuildpacks(goBuildpack).
+					WithPullPolicy("never").
+					Execute(name, source)
+				Expect(err).NotTo(HaveOccurred(), logs.String())
+
+				container, err = docker.Container.Run.
+					WithEnv(map[string]string{"PORT": "8080"}).
+					WithPublish("8080").
+					WithPublishAll().
+					Execute(image.ID)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(container).Should(BeAvailable())
+
+				response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
+				Expect(err).NotTo(HaveOccurred())
+				defer response.Body.Close()
+
+				Expect(response.StatusCode).To(Equal(http.StatusOK))
+
+				content, err := ioutil.ReadAll(response.Body)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(content)).To(Equal("Hello world!"))
+
+				Expect(logs).To(ContainLines(ContainSubstring("Go Distribution Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Go Mod Vendor Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Go Build Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Procfile Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("web: /layers/paketo-buildpacks_go-build/targets/bin/go-online --some-arg")))
+			})
+		})
 	})
 }

--- a/package.toml
+++ b/package.toml
@@ -16,3 +16,6 @@
 
 [[dependencies]]
   uri = "docker://gcr.io/paketo-buildpacks/go-build:0.1.2"
+
+[[dependencies]]
+  uri = "docker://gcr.io/paketo-buildpacks/procfile:3.0.0"


### PR DESCRIPTION
Thanks for contributing. To speed up the process of reviewing your pull request
please provide us with:

* A short explanation of the proposed change:
Add procfile to order-groups

* An explanation of the use cases your change enables:
Set start commands via Procfile

Please confirm the following:
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have added an integration test, if necessary.
