### PR TITLE
Add image labels buildpack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -27,6 +27,11 @@ api = "0.2"
     optional = true
     version = "4.0.0"
 
+  [[order.group]]
+    id = "paketo-buildpacks/image-labels"
+    optional = true
+    version = "3.0.0"
+
 [[order]]
 
   [[order.group]]
@@ -50,6 +55,11 @@ api = "0.2"
     optional = true
     version = "4.0.0"
 
+  [[order.group]]
+    id = "paketo-buildpacks/image-labels"
+    optional = true
+    version = "3.0.0"
+
 [[order]]
 
   [[order.group]]
@@ -64,3 +74,8 @@ api = "0.2"
     id = "paketo-buildpacks/procfile"
     optional = true
     version = "4.0.0"
+
+  [[order.group]]
+    id = "paketo-buildpacks/image-labels"
+    optional = true
+    version = "3.0.0"

--- a/integration/build_test.go
+++ b/integration/build_test.go
@@ -87,19 +87,23 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Go Mod Vendor Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Dep Buildpack")))
+			Expect(logs).NotTo(ContainLines(ContainSubstring("Image Labels Buildpack")))
 		})
 
-		context("when there is a Procfile", func() {
+		context("using optional utiliity buildpacks", func() {
 			it.Before(func() {
 				Expect(ioutil.WriteFile(filepath.Join(source, "Procfile"), []byte("web: /layers/paketo-buildpacks_go-build/targets/bin/workspace --some-arg"), 0644)).To(Succeed())
 			})
 
-			it("uses Procfile to set start command", func() {
+			it("builds a working OCI image with start command from the Procfile and incorporating the utility buildpacks' effects", func() {
 				var err error
 				var logs fmt.Stringer
 				image, logs, err = pack.WithNoColor().Build.
 					WithBuildpacks(goBuildpack).
 					WithPullPolicy("never").
+					WithEnv(map[string]string{
+						"BP_IMAGE_LABELS": "some-label=some-value",
+					}).
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred(), logs.String())
 
@@ -126,6 +130,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Go Build Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Procfile Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("web: /layers/paketo-buildpacks_go-build/targets/bin/workspace --some-arg")))
+				Expect(logs).To(ContainLines(ContainSubstring("Image Labels Buildpack")))
+				Expect(image.Labels["some-label"]).To(Equal("some-value"))
 			})
 		})
 	})

--- a/integration/dep_test.go
+++ b/integration/dep_test.go
@@ -88,19 +88,23 @@ func testDep(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(ContainSubstring("Go Build Buildpack")))
 
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Go Mod Vendor Buildpack")))
+			Expect(logs).NotTo(ContainLines(ContainSubstring("Image Labels Buildpack")))
 		})
 
-		context("when there is a Procfile", func() {
+		context("using optional utiliity buildpacks", func() {
 			it.Before(func() {
 				Expect(ioutil.WriteFile(filepath.Join(source, "Procfile"), []byte("web: /layers/paketo-buildpacks_go-build/targets/bin/workspace --some-arg"), 0644)).To(Succeed())
 			})
 
-			it("uses Procfile to set start command", func() {
+			it("builds a working OCI image with start command from the Procfile and incorporating the utility buildpacks' effects", func() {
 				var err error
 				var logs fmt.Stringer
 				image, logs, err = pack.WithNoColor().Build.
 					WithBuildpacks(goBuildpack).
 					WithPullPolicy("never").
+					WithEnv(map[string]string{
+						"BP_IMAGE_LABELS": "some-label=some-value",
+					}).
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred(), logs.String())
 
@@ -129,6 +133,8 @@ func testDep(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Go Build Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Procfile Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("web: /layers/paketo-buildpacks_go-build/targets/bin/workspace --some-arg")))
+				Expect(logs).To(ContainLines(ContainSubstring("Image Labels Buildpack")))
+				Expect(image.Labels["some-label"]).To(Equal("some-value"))
 			})
 		})
 	})

--- a/package.toml
+++ b/package.toml
@@ -19,3 +19,6 @@
 
 [[dependencies]]
   uri = "docker://gcr.io/paketo-buildpacks/procfile:4.0.0"
+
+[[dependencies]]
+  uri = "docker://gcr.io/paketo-buildpacks/image-labels:3.0.0"


### PR DESCRIPTION

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Resolves #8 
## Use Cases
<!-- An explanation of the use cases your change enables -->
Buildpack users can now add arbitrary labels to their go images.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have added an integration test, if necessary.
