### PR TITLE
Refactors tests

### DIFF
--- a/integration/build_test.go
+++ b/integration/build_test.go
@@ -3,7 +3,6 @@ package integration_test
 import (
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -70,17 +69,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(container).Should(BeAvailable())
-
-			response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
-			Expect(err).NotTo(HaveOccurred())
-			defer response.Body.Close()
-
-			Expect(response.StatusCode).To(Equal(http.StatusOK))
-
-			content, err := ioutil.ReadAll(response.Body)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(content)).To(Equal("Hello world!"))
+			Eventually(container).Should(Serve(ContainSubstring("Hello, World!")).OnPort(8080))
 
 			Expect(logs).To(ContainLines(ContainSubstring("Go Distribution Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Go Build Buildpack")))
@@ -110,10 +99,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred(), logs.String())
 
-				Expect(image.Buildpacks[3].Key).To(Equal("paketo-buildpacks/environment-variables"))
-				Expect(image.Buildpacks[3].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
-				Expect(image.Labels["some-label"]).To(Equal("some-value"))
-
 				container, err = docker.Container.Run.
 					WithEnv(map[string]string{"PORT": "8080"}).
 					WithPublish("8080").
@@ -121,17 +106,11 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					Execute(image.ID)
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(container).Should(BeAvailable())
+				Eventually(container).Should(Serve(ContainSubstring("Hello, World!")).OnPort(8080))
 
-				response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
-				Expect(err).NotTo(HaveOccurred())
-				defer response.Body.Close()
-
-				Expect(response.StatusCode).To(Equal(http.StatusOK))
-
-				content, err := ioutil.ReadAll(response.Body)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(string(content)).To(Equal("Hello world!"))
+				Expect(image.Buildpacks[3].Key).To(Equal("paketo-buildpacks/environment-variables"))
+				Expect(image.Buildpacks[3].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+				Expect(image.Labels["some-label"]).To(Equal("some-value"))
 
 				Expect(logs).To(ContainLines(ContainSubstring("Go Distribution Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Go Build Buildpack")))
@@ -184,17 +163,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(container).Should(BeAvailable())
-
-			response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
-			Expect(err).NotTo(HaveOccurred())
-			defer response.Body.Close()
-
-			Expect(response.StatusCode).To(Equal(http.StatusOK))
-
-			content, err := ioutil.ReadAll(response.Body)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(content)).To(Equal("Hello world!"))
+			Eventually(container).Should(Serve(ContainSubstring("Hello, World!")).OnPort(8080))
 
 			Expect(logs).To(ContainLines(ContainSubstring("Go Distribution Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Go Build Buildpack")))
@@ -248,17 +217,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(container).Should(BeAvailable())
-
-			response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
-			Expect(err).NotTo(HaveOccurred())
-			defer response.Body.Close()
-
-			Expect(response.StatusCode).To(Equal(http.StatusOK))
-
-			content, err := ioutil.ReadAll(response.Body)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(content)).To(ContainSubstring("Hello, World!"))
+			Eventually(container).Should(Serve(ContainSubstring("Hello, World!")).OnPort(8080))
 
 			Expect(logs).To(ContainLines(ContainSubstring("Go Distribution Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Go Build Buildpack")))

--- a/integration/testdata/build/main.go
+++ b/integration/testdata/build/main.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 	http.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
-		fmt.Fprint(w, "Hello world!")
+		fmt.Fprint(w, "Hello, World!")
 	})
 
 	log.Fatal(http.ListenAndServe(":"+os.Getenv("PORT"), nil))

--- a/integration/testdata/go_mod/site.go
+++ b/integration/testdata/go_mod/site.go
@@ -37,5 +37,5 @@ func main() {
 }
 
 func hello(res http.ResponseWriter, req *http.Request) {
-	fmt.Fprint(res, "Hello world!")
+	fmt.Fprint(res, "Hello, World!")
 }

--- a/integration/testdata/go_mod_vendored/site.go
+++ b/integration/testdata/go_mod_vendored/site.go
@@ -37,5 +37,5 @@ func main() {
 }
 
 func hello(res http.ResponseWriter, req *http.Request) {
-	fmt.Fprint(res, "Hello world!")
+	fmt.Fprint(res, "Hello, World!")
 }


### PR DESCRIPTION
- Moves image expectations after the image has pushed to avoid errors
from those expectations getting clobbered by the error messages of trying
to delete a non running container
- Uses the new Occam Serve matcher to clean up tests

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have added an integration test, if necessary.
