### PR TITLE
add watchexec to order groups for BP_LIVE_RELOAD_ENABLED

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -20,6 +20,11 @@ api = "0.4"
     version = "2.4.2"
 
   [[order.group]]
+    id = "paketo-buildpacks/watchexec"
+    optional = true
+    version = "1.2.0"
+
+  [[order.group]]
     id = "paketo-buildpacks/go-dist"
     version = "0.7.0"
 
@@ -52,6 +57,11 @@ api = "0.4"
     id = "paketo-buildpacks/ca-certificates"
     optional = true
     version = "2.4.2"
+
+  [[order.group]]
+    id = "paketo-buildpacks/watchexec"
+    optional = true
+    version = "1.2.0"
 
   [[order.group]]
     id = "paketo-buildpacks/go-dist"
@@ -90,6 +100,11 @@ api = "0.4"
     id = "paketo-buildpacks/ca-certificates"
     optional = true
     version = "2.4.2"
+
+  [[order.group]]
+    id = "paketo-buildpacks/watchexec"
+    optional = true
+    version = "1.2.0"
 
   [[order.group]]
     id = "paketo-buildpacks/go-dist"

--- a/integration/build_test.go
+++ b/integration/build_test.go
@@ -96,8 +96,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					WithBuildpacks(goBuildpack).
 					WithPullPolicy("never").
 					WithEnv(map[string]string{
-						"BPE_SOME_VARIABLE": "some-value",
-						"BP_IMAGE_LABELS":   "some-label=some-value",
+						"BPE_SOME_VARIABLE":      "some-value",
+						"BP_IMAGE_LABELS":        "some-label=some-value",
+						"BP_LIVE_RELOAD_ENABLED": "true",
 					}).
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred(), logs.String())
@@ -111,8 +112,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 				Eventually(container).Should(Serve(ContainSubstring("Hello, World!")).OnPort(8080))
 
-				Expect(image.Buildpacks[4].Key).To(Equal("paketo-buildpacks/environment-variables"))
-				Expect(image.Buildpacks[4].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+				Expect(image.Buildpacks[5].Key).To(Equal("paketo-buildpacks/environment-variables"))
+				Expect(image.Buildpacks[5].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 				Expect(image.Labels["some-label"]).To(Equal("some-value"))
 
 				Expect(logs).To(ContainLines(ContainSubstring("Go Distribution Buildpack")))
@@ -121,6 +122,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("web: /layers/paketo-buildpacks_go-build/targets/bin/workspace --some-arg")))
 				Expect(logs).To(ContainLines(ContainSubstring("Environment Variables Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Image Labels Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Watchexec Buildpack")))
 			})
 		})
 

--- a/integration/dep_test.go
+++ b/integration/dep_test.go
@@ -97,8 +97,9 @@ func testDep(t *testing.T, context spec.G, it spec.S) {
 					WithBuildpacks(goBuildpack).
 					WithPullPolicy("never").
 					WithEnv(map[string]string{
-						"BPE_SOME_VARIABLE": "some-value",
-						"BP_IMAGE_LABELS":   "some-label=some-value",
+						"BPE_SOME_VARIABLE":      "some-value",
+						"BP_IMAGE_LABELS":        "some-label=some-value",
+						"BP_LIVE_RELOAD_ENABLED": "true",
 					}).
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred(), logs.String())
@@ -112,8 +113,8 @@ func testDep(t *testing.T, context spec.G, it spec.S) {
 
 				Eventually(container).Should(Serve(ContainSubstring("Hello, World!")).OnPort(8080))
 
-				Expect(image.Buildpacks[6].Key).To(Equal("paketo-buildpacks/environment-variables"))
-				Expect(image.Buildpacks[6].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+				Expect(image.Buildpacks[7].Key).To(Equal("paketo-buildpacks/environment-variables"))
+				Expect(image.Buildpacks[7].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 				Expect(image.Labels["some-label"]).To(Equal("some-value"))
 
 				Expect(logs).To(ContainLines(ContainSubstring("Go Distribution Buildpack")))
@@ -124,6 +125,7 @@ func testDep(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("web: /layers/paketo-buildpacks_go-build/targets/bin/workspace --some-arg")))
 				Expect(logs).To(ContainLines(ContainSubstring("Environment Variables Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Image Labels Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Watchexec Buildpack")))
 			})
 		})
 

--- a/integration/go_mod_test.go
+++ b/integration/go_mod_test.go
@@ -96,8 +96,9 @@ func testGoMod(t *testing.T, context spec.G, it spec.S) {
 					WithBuildpacks(goBuildpack).
 					WithPullPolicy("never").
 					WithEnv(map[string]string{
-						"BPE_SOME_VARIABLE": "some-value",
-						"BP_IMAGE_LABELS":   "some-label=some-value",
+						"BPE_SOME_VARIABLE":      "some-value",
+						"BP_IMAGE_LABELS":        "some-label=some-value",
+						"BP_LIVE_RELOAD_ENABLED": "true",
 					}).
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred(), logs.String())
@@ -111,8 +112,8 @@ func testGoMod(t *testing.T, context spec.G, it spec.S) {
 
 				Eventually(container).Should(Serve(ContainSubstring("Hello, World!")).OnPort(8080))
 
-				Expect(image.Buildpacks[5].Key).To(Equal("paketo-buildpacks/environment-variables"))
-				Expect(image.Buildpacks[5].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+				Expect(image.Buildpacks[6].Key).To(Equal("paketo-buildpacks/environment-variables"))
+				Expect(image.Buildpacks[6].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 				Expect(image.Labels["some-label"]).To(Equal("some-value"))
 
 				Expect(logs).To(ContainLines(ContainSubstring("Go Distribution Buildpack")))
@@ -122,6 +123,7 @@ func testGoMod(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("web: /layers/paketo-buildpacks_go-build/targets/bin/go-online --some-arg")))
 				Expect(logs).To(ContainLines(ContainSubstring("Environment Variables Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Image Labels Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Watchexec Buildpack")))
 			})
 		})
 

--- a/package.toml
+++ b/package.toml
@@ -28,3 +28,6 @@
 
 [[dependencies]]
   uri = "docker://gcr.io/paketo-buildpacks/ca-certificates:2.4.2"
+
+[[dependencies]]
+  uri = "docker://gcr.io/paketo-buildpacks/watchexec:1.2.0"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
go-build [v0.5.0](https://github.com/paketo-buildpacks/go-build/releases/tag/v0.5.0) includes support for `BP_LIVE_RELOAD_ENABLED`. For Go language family buildpack users to get the benefit of this environment variable, the language family must include the Watchexec buildpack as an optional component.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
