### PR TITLE
Add integration tests for reloadable container startup

### DIFF
--- a/integration/dep_test.go
+++ b/integration/dep_test.go
@@ -86,8 +86,13 @@ func testDep(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		context("when using utility buildpacks", func() {
+			var procfileContainer occam.Container
 			it.Before(func() {
-				Expect(ioutil.WriteFile(filepath.Join(source, "Procfile"), []byte("web: /layers/paketo-buildpacks_go-build/targets/bin/workspace --some-arg"), 0600)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(source, "Procfile"), []byte("procfile: echo Procfile command"), 0644)).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(docker.Container.Remove.Execute(procfileContainer.ID)).To(Succeed())
 			})
 
 			it("builds a working OCI image with start command from the Procfile and incorporating the utility buildpacks' effects", func() {
@@ -104,15 +109,6 @@ func testDep(t *testing.T, context spec.G, it spec.S) {
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred(), logs.String())
 
-				container, err = docker.Container.Run.
-					WithEnv(map[string]string{"PORT": "8080"}).
-					WithPublish("8080").
-					WithPublishAll().
-					Execute(image.ID)
-				Expect(err).NotTo(HaveOccurred())
-
-				Eventually(container).Should(Serve(ContainSubstring("Hello, World!")).OnPort(8080))
-
 				Expect(image.Buildpacks[7].Key).To(Equal("paketo-buildpacks/environment-variables"))
 				Expect(image.Buildpacks[7].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 				Expect(image.Labels["some-label"]).To(Equal("some-value"))
@@ -122,10 +118,28 @@ func testDep(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Dep Ensure Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Go Build Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Procfile Buildpack")))
-				Expect(logs).To(ContainLines(ContainSubstring("web: /layers/paketo-buildpacks_go-build/targets/bin/workspace --some-arg")))
 				Expect(logs).To(ContainLines(ContainSubstring("Environment Variables Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Image Labels Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Watchexec Buildpack")))
+
+				container, err = docker.Container.Run.
+					WithEnv(map[string]string{"PORT": "8080"}).
+					WithPublish("8080").
+					WithPublishAll().
+					Execute(image.ID)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(container).Should(Serve(ContainSubstring("Hello, World!")).OnPort(8080))
+
+				procfileContainer, err = docker.Container.Run.
+					WithEntrypoint("procfile").
+					Execute(image.ID)
+				Expect(err).NotTo(HaveOccurred())
+
+				containerLogs, err := docker.Container.Logs.Execute(procfileContainer.ID)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(containerLogs.String()).To(ContainSubstring("Procfile command"))
 			})
 		})
 

--- a/integration/go_mod_test.go
+++ b/integration/go_mod_test.go
@@ -85,8 +85,13 @@ func testGoMod(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		context("when using utility buildpacks", func() {
+			var procfileContainer occam.Container
 			it.Before(func() {
-				Expect(ioutil.WriteFile(filepath.Join(source, "Procfile"), []byte("web: /layers/paketo-buildpacks_go-build/targets/bin/go-online --some-arg"), 0600)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(source, "Procfile"), []byte("procfile: echo Procfile command"), 0644)).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(docker.Container.Remove.Execute(procfileContainer.ID)).To(Succeed())
 			})
 
 			it("builds a working OCI image with start command from the Procfile and incorporating the utility buildpacks' effects", func() {
@@ -103,6 +108,18 @@ func testGoMod(t *testing.T, context spec.G, it spec.S) {
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred(), logs.String())
 
+				Expect(image.Buildpacks[6].Key).To(Equal("paketo-buildpacks/environment-variables"))
+				Expect(image.Buildpacks[6].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+				Expect(image.Labels["some-label"]).To(Equal("some-value"))
+
+				Expect(logs).To(ContainLines(ContainSubstring("Go Distribution Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Go Mod Vendor Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Go Build Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Procfile Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Environment Variables Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Image Labels Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Watchexec Buildpack")))
+
 				container, err = docker.Container.Run.
 					WithEnv(map[string]string{"PORT": "8080"}).
 					WithPublish("8080").
@@ -112,18 +129,15 @@ func testGoMod(t *testing.T, context spec.G, it spec.S) {
 
 				Eventually(container).Should(Serve(ContainSubstring("Hello, World!")).OnPort(8080))
 
-				Expect(image.Buildpacks[6].Key).To(Equal("paketo-buildpacks/environment-variables"))
-				Expect(image.Buildpacks[6].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
-				Expect(image.Labels["some-label"]).To(Equal("some-value"))
+				procfileContainer, err = docker.Container.Run.
+					WithEntrypoint("procfile").
+					Execute(image.ID)
+				Expect(err).NotTo(HaveOccurred())
 
-				Expect(logs).To(ContainLines(ContainSubstring("Go Distribution Buildpack")))
-				Expect(logs).To(ContainLines(ContainSubstring("Go Mod Vendor Buildpack")))
-				Expect(logs).To(ContainLines(ContainSubstring("Go Build Buildpack")))
-				Expect(logs).To(ContainLines(ContainSubstring("Procfile Buildpack")))
-				Expect(logs).To(ContainLines(ContainSubstring("web: /layers/paketo-buildpacks_go-build/targets/bin/go-online --some-arg")))
-				Expect(logs).To(ContainLines(ContainSubstring("Environment Variables Buildpack")))
-				Expect(logs).To(ContainLines(ContainSubstring("Image Labels Buildpack")))
-				Expect(logs).To(ContainLines(ContainSubstring("Watchexec Buildpack")))
+				containerLogs, err := docker.Container.Logs.Execute(procfileContainer.ID)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(containerLogs.String()).To(ContainSubstring("Procfile command"))
 			})
 		})
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Adds integration test assertions that make sure containers with reloadable processes start correctly. This will guard against issues integrating the Watchexec buildpack with the go-build buildpack.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
