### PR TITLE
Add Go Binary SBOM Assertions

### DIFF
--- a/integration/go_mod_test.go
+++ b/integration/go_mod_test.go
@@ -109,12 +109,10 @@ func testGoMod(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(contents)).To(ContainSubstring(`"name": "github.com/BurntSushi/toml"`))
 
-			/*The below assertions are commented out until anchore/syft#871 is resolved
-			or we find a workaround */
 			// check an SBOM file to make sure it contains entries for built binary
-			// contents, err = os.ReadFile(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_go-build", "targets", "sbom.cdx.json"))
-			// Expect(err).NotTo(HaveOccurred())
-			// Expect(string(contents)).To(ContainSubstring(`"name": "github.com/BurntSushi/toml"`))
+			contents, err = os.ReadFile(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_go-build", "targets", "sbom.cdx.json"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(contents)).To(ContainSubstring(`"name": "github.com/BurntSushi/toml"`))
 		})
 
 		context("when using utility buildpacks", func() {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Now that https://github.com/paketo-buildpacks/go-build/issues/287 is resolved and released in go-build v1.1.1, Go language family includes support for Go  modules in the SBOM attached to the go binary layer.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
