### PR TITLE
buildpack.toml: nitpick

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -117,13 +117,13 @@ api = "0.6"
     version = "2.4.0"
 
   [[order.group]]
+    id = "paketo-buildpacks/go-dist"
+    version = "1.1.3"
+
+  [[order.group]]
     id = "paketo-buildpacks/git"
     optional = true
     version = "0.4.2"
-
-  [[order.group]]
-    id = "paketo-buildpacks/go-dist"
-    version = "1.1.3"
 
   [[order.group]]
     id = "paketo-buildpacks/go-build"


### PR DESCRIPTION
Sorry - easy for brain when go-dist and git have the same relative ordering everywhere