### PR TITLE
chore(readme): Update image location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Go Paketo Buildpack
 
-## `gcr.io/paketo-buildpacks/go`
+## `docker.io/paketobuildpacks/go`
 
 The Go Paketo Buildpack provides a set of collaborating buildpacks that
 enable the building of a Go-based application. These buildpacks include:


### PR DESCRIPTION
## Summary

Since https://github.com/paketo-buildpacks/go/pull/1156 the buildpack is no longer pushed to `gcr.io` and is now available at `docker.io`. Still the `README` references it at the top.

Closes: #1151 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
